### PR TITLE
Adding A Convar for the SideKick Deagle

### DIFF
--- a/lua/autorun/sh_jackal_convars.lua
+++ b/lua/autorun/sh_jackal_convars.lua
@@ -6,5 +6,5 @@ hook.Add("TTTUlxDynamicRCVars", "ttt2_ulx_dynamic_jackal_convars", function(tbl)
 	tbl[ROLE_JACKAL] = tbl[ROLE_JACKAL] or {}
 
 	table.insert(tbl[ROLE_JACKAL], {cvar = "ttt_jackal_armor_value", slider = true, min = 0, max = 100, decimal = 0, desc = "ttt_jackal_armor_value (def. 30)"})
-	table.insert(tbl[ROLE_JACKAL], {cvar = "ttt_jackal_spawn_siki_deagle", checkbox = true, desc = "ttt_jackal_spawn_siki_deagle (def. true)"})
+	table.insert(tbl[ROLE_JACKAL], {cvar = "ttt_jackal_spawn_siki_deagle", checkbox = true, desc = "ttt_jackal_spawn_siki_deagle (def. 1)"})
 end)

--- a/lua/autorun/sh_jackal_convars.lua
+++ b/lua/autorun/sh_jackal_convars.lua
@@ -1,5 +1,6 @@
 -- replicated convars have to be created on both client and server
 CreateConVar("ttt_jackal_armor_value", 30, {FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED})
+CreateConVar("ttt_jackal_spawn_siki_deeagle", true, {FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED})
 
 hook.Add("TTTUlxDynamicRCVars", "ttt2_ulx_dynamic_jackal_convars", function(tbl)
 	tbl[ROLE_JACKAL] = tbl[ROLE_JACKAL] or {}

--- a/lua/autorun/sh_jackal_convars.lua
+++ b/lua/autorun/sh_jackal_convars.lua
@@ -1,9 +1,10 @@
 -- replicated convars have to be created on both client and server
 CreateConVar("ttt_jackal_armor_value", 30, {FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED})
-CreateConVar("ttt_jackal_spawn_siki_deeagle", true, {FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED})
+CreateConVar("ttt_jackal_spawn_siki_deeagle", 1, {FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED})
 
 hook.Add("TTTUlxDynamicRCVars", "ttt2_ulx_dynamic_jackal_convars", function(tbl)
 	tbl[ROLE_JACKAL] = tbl[ROLE_JACKAL] or {}
 
 	table.insert(tbl[ROLE_JACKAL], {cvar = "ttt_jackal_armor_value", slider = true, min = 0, max = 100, decimal = 0, desc = "ttt_jackal_armor_value (def. 30)"})
+	table.insert(tbl[ROLE_JACKAL], {cvar = "ttt_jackal_spawn_siki_deagle", checkbox = true, desc = "ttt_jackal_spawn_siki_deagle (def. true)"})
 end)

--- a/lua/autorun/sh_jackal_convars.lua
+++ b/lua/autorun/sh_jackal_convars.lua
@@ -1,6 +1,6 @@
 -- replicated convars have to be created on both client and server
 CreateConVar("ttt_jackal_armor_value", 30, {FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED})
-CreateConVar("ttt_jackal_spawn_siki_deeagle", 1, {FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED})
+CreateConVar("ttt_jackal_spawn_siki_deagle", 1, {FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED})
 
 hook.Add("TTTUlxDynamicRCVars", "ttt2_ulx_dynamic_jackal_convars", function(tbl)
 	tbl[ROLE_JACKAL] = tbl[ROLE_JACKAL] or {}

--- a/lua/terrortown/entities/roles/jackal/shared.lua
+++ b/lua/terrortown/entities/roles/jackal/shared.lua
@@ -19,6 +19,10 @@ function ROLE:PreInitialize()
 	self.scoreKillsMultiplier = 1 -- multiplier for kill of player of another team
 	self.scoreTeamKillsMultiplier = -8 -- multiplier for teamkill
 	self.fallbackTable = {}
+	if not GetConVar("ttt_jackal_spawn_siki_deagle"):GetBoolean() then 
+		table.insert(self.fallbackTable, {id = "weapon_ttt2_sidekickdeagle"}) 
+	end
+	
 	self.traitorCreditAward = true -- will receive credits on kill like a traitor
 
 	self.defaultTeam = TEAM_JACKAL -- the team name: roles with same team name are working together
@@ -93,7 +97,8 @@ if SERVER then
 
 	-- Give Loadout on respawn and rolechange
 	function ROLE:GiveRoleLoadout(ply, isRoleChange)
-		if isRoleChange and WEPS.IsInstalled("weapon_ttt2_sidekickdeagle") then -- TODO: maybe give SiKi deagle on respawn if not used before
+		if isRoleChange and WEPS.IsInstalled("weapon_ttt2_sidekickdeagle")
+			and GetConVar("ttt_jackal_spawn_siki_deagle"):GetBool() then -- TODO: maybe give SiKi deagle on respawn if not used before
 			ply:GiveEquipmentWeapon("weapon_ttt2_sidekickdeagle")
 		end
 


### PR DESCRIPTION
This Pullrequest adds a ConVar to determine whether or not the Jackal should spawn with the sidekick deagle in his inventory or not. In case you choose not to, it will be added to the Jackal shop and thereby available for purchase.